### PR TITLE
Setup project structure

### DIFF
--- a/artifacts/.gitkeep
+++ b/artifacts/.gitkeep
@@ -1,0 +1,7 @@
+# This directory is reserved for Kubernetes manifest like the Flux daemon
+# and the Flux Helm operator. Each branch reflecting an environment should
+# change the configurations of these manifests according to their requirements.
+#
+# For the dameon this would at least be different --git-branch and --git-label
+# flags.
+

--- a/charts/.gitkeep
+++ b/charts/.gitkeep
@@ -1,0 +1,6 @@
+# This directory is reserved for Helm charts required by the Flux Helm
+# operator.
+#
+# The operator should be configured with the --git-charts-path flag set
+# to 'charts' and the --git-branch set to the environment branch.
+

--- a/config/.gitkeep
+++ b/config/.gitkeep
@@ -1,0 +1,8 @@
+# This is the directory the Flux daemon will keep an eye on.
+#
+# All Kubernetes manifests Flux should have control over should
+# be kept here.
+#
+# Matching configuration flag for the Flux dameon is
+# --git-path=config
+


### PR DESCRIPTION
Base structure for a cluster environment, inherited from https://github.com/weaveworks/flux-helm-test.

This structure allows the deployment of the Flux Helm operator if required.

`artifacts/*`
Should contain Kubernetes manifests for the Flux daemon in the future.

`charts/*`
Is reserved for Helm charts.

`config/*`
Home to all Kubernetes manifests the Flux daemon should have control over.